### PR TITLE
Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ

### DIFF
--- a/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/k8s/deployment.yaml
+++ b/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/k8s/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otus-ms-deployment
+  labels:
+    app: otus-ms
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: otus-ms
+  template:
+    metadata:
+      labels:
+        app: otus-ms
+    spec:
+      containers:
+      - name: otus-ms
+        image: hoborg91/otus-ms:latest
+        ports:
+        - containerPort: 8000

--- a/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/k8s/ingress.yaml
+++ b/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/k8s/ingress.yaml
@@ -1,6 +1,9 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
   name: otus-ms-ingress
   namespace: default
 spec:
@@ -9,10 +12,10 @@ spec:
     - host: arch.homework
       http:
         paths:
-          - pathType: Prefix
+          - pathType: ImplementationSpecific
             backend:
               service:
                 name: otus-ms-service
                 port:
                   number: 80
-            path: /
+            path: /otusapp/(.+?)/(.*)

--- a/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/k8s/ingress.yaml
+++ b/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/k8s/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: otus-ms-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: arch.homework
+      http:
+        paths:
+          - pathType: Prefix
+            backend:
+              service:
+                name: otus-ms-service
+                port:
+                  number: 80
+            path: /

--- a/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/k8s/service.yaml
+++ b/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: otus-ms-service
+spec:
+  selector:
+    app: otus-ms
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/nginx-ingress.yaml
+++ b/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/nginx-ingress.yaml
@@ -1,0 +1,13 @@
+controller:
+  kind: DaemonSet
+  
+  reportNodeInternalIp: true
+
+  hostPort:
+    enabled: true
+    ports:
+      http: 80
+      https: 443
+
+  service:
+    type: NodePort

--- a/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/otus-ms-hw-3-k8s-basics.postman_collection.json
+++ b/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/otus-ms-hw-3-k8s-basics.postman_collection.json
@@ -1,0 +1,103 @@
+{
+	"info": {
+		"_postman_id": "1f3dac54-1a84-4999-b07c-8dad48adb2d4",
+		"name": "otus-ms-hw-3-k8s-basics",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "34900798"
+	},
+	"item": [
+		{
+			"name": "curl arch.homework/otusapp/aeugene/health yields {\"status\":\"OK\"}",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Response status code is 200\", function () {\r",
+							"  pm.expect(pm.response.code).to.equal(200);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Response time is within an acceptable range\", function () {\r",
+							"  pm.expect(pm.response.responseTime).to.be.below(1000);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Content-Type header is application/json\", function () {\r",
+							"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Status field equals 'OK'\", function () {\r",
+							"    const responseData = pm.response.json();\r",
+							"    \r",
+							"    pm.expect(responseData).to.be.an('object');\r",
+							"    pm.expect(responseData.status).to.eq(\"OK\");\r",
+							"});\r",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "arch.homework/otusapp/aeugene/health",
+					"host": [
+						"arch",
+						"homework"
+					],
+					"path": [
+						"otusapp",
+						"aeugene",
+						"health"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "New Request",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "arch.homework/otusapp/aeugene/health",
+							"host": [
+								"arch",
+								"homework"
+							],
+							"path": [
+								"otusapp",
+								"aeugene",
+								"health"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Mon, 13 May 2024 18:56:20 GMT"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8"
+						},
+						{
+							"key": "Transfer-Encoding",
+							"value": "chunked"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"status\": \"OK\"\n}"
+				}
+			]
+		}
+	]
+}

--- a/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/readme.md
+++ b/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/readme.md
@@ -6,7 +6,7 @@
 
 Описание/Пошаговая инструкция выполнения домашнего задания:
 
-Шаг 1. Создать минимальный сервис, который
+**Шаг 1**. Создать минимальный сервис, который
 
 отвечает на порту 8000
 имеет http-метод
@@ -15,11 +15,11 @@ GET /health/
 
 RESPONSE: {"status": "OK"}
 
-Шаг 2. Cобрать локально образ приложения в докер.
+**Шаг 2**. Cобрать локально образ приложения в докер.
 
 Запушить образ в dockerhub
 
-Шаг 3. Написать манифесты для деплоя в k8s для этого сервиса.
+**Шаг 3**. Написать манифесты для деплоя в k8s для этого сервиса.
 
 Манифесты должны описывать сущности: Deployment, Service, Ingress.
 
@@ -29,7 +29,7 @@ RESPONSE: {"status": "OK"}
 
 Хост в ингрессе должен быть arch.homework. В итоге после применения манифестов GET запрос на http://arch.homework/health должен отдавать {“status”: “OK”}.
 
-Шаг 4. На выходе предоставить
+**Шаг 4**. На выходе предоставить
 
 0) ссылку на github c манифестами. Манифесты должны лежать в одной директории, так чтобы можно было их все применить одной командой kubectl apply -f .
 
@@ -41,7 +41,7 @@ RESPONSE: {"status": "OK"}
 
 Например: curl arch.homework/otusapp/aeugene/health -> рерайт пути на arch.homework/health
 
-Рекомендации по форме сдачи дз:
+**Рекомендации по форме сдачи дз:**
 
 * использовать nginx ingress контроллер, установленный через хелм, а не встроенный в миникубик:
 kubectl create namespace m && helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx/ && helm repo update && helm install nginx ingress-nginx/ingress-nginx --namespace m -f nginx-ingress.yaml (файл приложен к занятию)
@@ -60,19 +60,52 @@ docker build --platform linux/amd64 -t tag .
 
 Более подробно можно прочитать в статье: https://programmerah.com/how-to-solve-docker-run-error-standard_init_linux-go219-exec-user-process-caused-exec-format-error-39221/
 
-Критерии оценки:
+**Критерии оценки:**
 
 "Принято" - задание выполнено полностью
 "Возвращено на доработку" - задание не выполнено полностью
 
-# Шпаргалка
+# Проект проверки задания на Windows 10 Pro 22H2, x64
 
-Запустить cmd от имени администратора.
+## Предпосылки
 
-docker context use default
-minikube start (первый раз после установки: minikube start --vm-driver=hyperv)
-minikube addons enable ingress
-kubectl apply -f .
-curl http://arch.homework/health/ (ожидаемый ответ: {"status":"OK"})
-minikube delete --all
-minikube stop && minikube start
+* Установлен Docker 26.0.0.
+* Установлен Kubernetes (клиент v1.29.2, сервер v1.30.0).
+* Установлен Minikube v1.33.0 с драйвером ВМ hyperv.
+* Установлен Node.js v18.10.0.
+* Установлен Newman (npm install -g newman).
+
+## Шаги
+
+Запустить командную строку (cmd) от имени администратора, перейти в папку "Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ" и выполнить указанные ниже команды.
+
+    docker context use default
+    minikube start
+
+Первый раз после установки Minikube вместо команды `minikube start` следует выполнить `minikube start --vm-driver=hyperv`.
+
+    minikube addons enable ingress
+    kubectl apply -f k8s\.
+    minikube ip
+
+Сделать в файле *hosts* запись `arch.homework` с адресом, полученным с помощью последней команды, например, `1.2.3.4 arch.homework`.
+
+    newman run otus-ms-hw-3-k8s-basics.postman_collection.json
+
+Пример ожидаемого результата:
+
+	newman
+
+	otus-ms-hw-3-k8s-basics
+
+	→ curl arch.homework/otusapp/aeugene/health yields {"status":"OK"}
+	  GET arch.homework/otusapp/aeugene/health [200 OK, 170B, 88ms]
+	  √  Response status code is 200
+	  √  Response time is within an acceptable range
+	  √  Content-Type header is application/json
+	  √  Status field equals 'OK'
+    
+Для остановки и удаления кластера Minikube надо выполнить следующее.
+
+    minikube stop
+    minikube delete --all

--- a/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/readme.md
+++ b/Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ/readme.md
@@ -1,0 +1,78 @@
+# Домашнее задание: Основы работы с Kubernetes (Часть 2)
+
+Цель:
+
+В этом ДЗ вы научитесь создавать минимальный сервис.
+
+Описание/Пошаговая инструкция выполнения домашнего задания:
+
+Шаг 1. Создать минимальный сервис, который
+
+отвечает на порту 8000
+имеет http-метод
+
+GET /health/
+
+RESPONSE: {"status": "OK"}
+
+Шаг 2. Cобрать локально образ приложения в докер.
+
+Запушить образ в dockerhub
+
+Шаг 3. Написать манифесты для деплоя в k8s для этого сервиса.
+
+Манифесты должны описывать сущности: Deployment, Service, Ingress.
+
+В Deployment могут быть указаны Liveness, Readiness пробы.
+
+Количество реплик должно быть не меньше 2. Image контейнера должен быть указан с Dockerhub.
+
+Хост в ингрессе должен быть arch.homework. В итоге после применения манифестов GET запрос на http://arch.homework/health должен отдавать {“status”: “OK”}.
+
+Шаг 4. На выходе предоставить
+
+0) ссылку на github c манифестами. Манифесты должны лежать в одной директории, так чтобы можно было их все применить одной командой kubectl apply -f .
+
+1) url, по которому можно будет получить ответ от сервиса (либо тест в postmanе).
+
+Задание со звездой:
+
+В Ingress-е должно быть правило, которое форвардит все запросы с /otusapp/{student name}/* на сервис с rewrite-ом пути. Где {student name} - это имя студента.
+
+Например: curl arch.homework/otusapp/aeugene/health -> рерайт пути на arch.homework/health
+
+Рекомендации по форме сдачи дз:
+
+* использовать nginx ingress контроллер, установленный через хелм, а не встроенный в миникубик:
+kubectl create namespace m && helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx/ && helm repo update && helm install nginx ingress-nginx/ingress-nginx --namespace m -f nginx-ingress.yaml (файл приложен к занятию)
+* https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/
+необходимо в новых версиях nginx добавлять класс ингресса
+ingressClassName: nginx
+* прикладывать к 2 дз урл для проверки: curl http://arch.homework/health или как указано в дз со *.
+К 3 дз и далее дз прикладывать коллекцию postman и проверять ее работу через newman run имя_коллекции
+прикладывать кроме команд разворачивания приложения, команду удаления)
+* прописать у себя в /etc/hosts хост arch.homework с адресом своего миникубика (minikube ip), чтобы обращение было по имени хоста в запросах, а не айпи
+* Обратите внимание, что при сборке на m1 при запуске вашего контейнера на стандартных платформах будет ошибка такого вида:
+standard_init_linux.go:228: exec user process caued: exec format error
+
+Для сборки рекомендую указать тип платформы linux/amd64:
+docker build --platform linux/amd64 -t tag .
+
+Более подробно можно прочитать в статье: https://programmerah.com/how-to-solve-docker-run-error-standard_init_linux-go219-exec-user-process-caused-exec-format-error-39221/
+
+Критерии оценки:
+
+"Принято" - задание выполнено полностью
+"Возвращено на доработку" - задание не выполнено полностью
+
+# Шпаргалка
+
+Запустить cmd от имени администратора.
+
+docker context use default
+minikube start (первый раз после установки: minikube start --vm-driver=hyperv)
+minikube addons enable ingress
+kubectl apply -f .
+curl http://arch.homework/health/ (ожидаемый ответ: {"status":"OK"})
+minikube delete --all
+minikube stop && minikube start


### PR DESCRIPTION
# Домашнее задание: Основы работы с Kubernetes (Часть 2)

Цель:

В этом ДЗ вы научитесь создавать минимальный сервис.

Описание/Пошаговая инструкция выполнения домашнего задания:

**Шаг 1**. Создать минимальный сервис, который

отвечает на порту 8000
имеет http-метод

GET /health/

RESPONSE: {"status": "OK"}

**Шаг 2**. Cобрать локально образ приложения в докер.

Запушить образ в dockerhub

**Шаг 3**. Написать манифесты для деплоя в k8s для этого сервиса.

Манифесты должны описывать сущности: Deployment, Service, Ingress.

В Deployment могут быть указаны Liveness, Readiness пробы.

Количество реплик должно быть не меньше 2. Image контейнера должен быть указан с Dockerhub.

Хост в ингрессе должен быть arch.homework. В итоге после применения манифестов GET запрос на http://arch.homework/health должен отдавать {“status”: “OK”}.

**Шаг 4**. На выходе предоставить

0) ссылку на github c манифестами. Манифесты должны лежать в одной директории, так чтобы можно было их все применить одной командой kubectl apply -f .

1) url, по которому можно будет получить ответ от сервиса (либо тест в postmanе).

Задание со звездой:

В Ingress-е должно быть правило, которое форвардит все запросы с /otusapp/{student name}/* на сервис с rewrite-ом пути. Где {student name} - это имя студента.

Например: curl arch.homework/otusapp/aeugene/health -> рерайт пути на arch.homework/health

**Рекомендации по форме сдачи дз:**

* использовать nginx ingress контроллер, установленный через хелм, а не встроенный в миникубик:
kubectl create namespace m && helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx/ && helm repo update && helm install nginx ingress-nginx/ingress-nginx --namespace m -f nginx-ingress.yaml (файл приложен к занятию)
* https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/
необходимо в новых версиях nginx добавлять класс ингресса
ingressClassName: nginx
* прикладывать к 2 дз урл для проверки: curl http://arch.homework/health или как указано в дз со *.
К 3 дз и далее дз прикладывать коллекцию postman и проверять ее работу через newman run имя_коллекции
прикладывать кроме команд разворачивания приложения, команду удаления)
* прописать у себя в /etc/hosts хост arch.homework с адресом своего миникубика (minikube ip), чтобы обращение было по имени хоста в запросах, а не айпи
* Обратите внимание, что при сборке на m1 при запуске вашего контейнера на стандартных платформах будет ошибка такого вида:
standard_init_linux.go:228: exec user process caued: exec format error

Для сборки рекомендую указать тип платформы linux/amd64:
docker build --platform linux/amd64 -t tag .

Более подробно можно прочитать в статье: https://programmerah.com/how-to-solve-docker-run-error-standard_init_linux-go219-exec-user-process-caused-exec-format-error-39221/

**Критерии оценки:**

"Принято" - задание выполнено полностью
"Возвращено на доработку" - задание не выполнено полностью

# Проект проверки задания на Windows 10 Pro 22H2, x64

## Предпосылки

* Установлен Docker 26.0.0.
* Установлен Kubernetes (клиент v1.29.2, сервер v1.30.0).
* Установлен Minikube v1.33.0 с драйвером ВМ hyperv.
* Установлен Node.js v18.10.0.
* Установлен Newman (npm install -g newman).

## Шаги

Запустить командную строку (cmd) от имени администратора, перейти в папку "Базовые сущности Кubernetes ReplicaSet, Deployment, Service, Ingress - ДЗ" и выполнить указанные ниже команды.

    docker context use default
    minikube start

Первый раз после установки Minikube вместо команды `minikube start` следует выполнить `minikube start --vm-driver=hyperv`.

    minikube addons enable ingress
    kubectl apply -f k8s\.
    minikube ip

Сделать в файле *hosts* запись `arch.homework` с адресом, полученным с помощью последней команды, например, `1.2.3.4 arch.homework`.

    newman run otus-ms-hw-3-k8s-basics.postman_collection.json

Пример ожидаемого результата:

	newman

	otus-ms-hw-3-k8s-basics

	→ curl arch.homework/otusapp/aeugene/health yields {"status":"OK"}
	  GET arch.homework/otusapp/aeugene/health [200 OK, 170B, 88ms]
	  √  Response status code is 200
	  √  Response time is within an acceptable range
	  √  Content-Type header is application/json
	  √  Status field equals 'OK'
    
Для остановки и удаления кластера Minikube надо выполнить следующее.

    minikube stop
    minikube delete --all
